### PR TITLE
Unix socket adaptor fix

### DIFF
--- a/app.go
+++ b/app.go
@@ -905,13 +905,33 @@ func (app *App) Group(prefix string, handlers ...Handler) Router {
 	return grp
 }
 
-// Route is used to define routes with a common prefix inside the common function.
-// Uses Group method to define new sub-router.
-func (app *App) Route(path string) Register {
+// RouteChain creates a Registering instance that lets you declare a stack of
+// handlers for the same route. Handlers defined via the returned Register are
+// scoped to the provided path.
+func (app *App) RouteChain(path string) Register {
 	// Create new route
 	route := &Registering{app: app, path: path}
 
 	return route
+}
+
+// Route is used to define routes with a common prefix inside the supplied
+// function. It mirrors the legacy helper and reuses the Group method to create
+// a sub-router.
+func (app *App) Route(prefix string, fn func(router Router), name ...string) Router {
+	if fn == nil {
+		panic("route handler 'fn' cannot be nil")
+	}
+	// Create new group
+	group := app.Group(prefix)
+	if len(name) > 0 {
+		group.Name(name[0])
+	}
+
+	// Define routes
+	fn(group)
+
+	return group
 }
 
 // Error makes it compatible with the `error` interface.

--- a/app_test.go
+++ b/app_test.go
@@ -1360,13 +1360,13 @@ func Test_App_Group(t *testing.T) {
 	require.Equal(t, 200, resp.StatusCode, "Status code")
 }
 
-func Test_App_Route(t *testing.T) {
+func Test_App_RouteChain(t *testing.T) {
 	t.Parallel()
 	dummyHandler := testEmptyHandler
 
 	app := New()
 
-	register := app.Route("/test").
+	register := app.RouteChain("/test").
 		Get(dummyHandler).
 		Head(dummyHandler).
 		Post(dummyHandler).
@@ -1387,7 +1387,7 @@ func Test_App_Route(t *testing.T) {
 	testStatus200(t, app, "/test", MethodTrace)
 	testStatus200(t, app, "/test", MethodPatch)
 
-	register.Route("/v1").Get(dummyHandler).Post(dummyHandler)
+	register.RouteChain("/v1").Get(dummyHandler).Post(dummyHandler)
 
 	resp, err := app.Test(httptest.NewRequest(MethodPost, "/test/v1", nil))
 	require.NoError(t, err, "app.Test(req)")
@@ -1397,7 +1397,7 @@ func Test_App_Route(t *testing.T) {
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, 200, resp.StatusCode, "Status code")
 
-	register.Route("/v1").Route("/v2").Route("/v3").Get(dummyHandler).Trace(dummyHandler)
+	register.RouteChain("/v1").RouteChain("/v2").RouteChain("/v3").Get(dummyHandler).Trace(dummyHandler)
 
 	resp, err = app.Test(httptest.NewRequest(MethodTrace, "/test/v1/v2/v3", nil))
 	require.NoError(t, err, "app.Test(req)")
@@ -1406,6 +1406,71 @@ func Test_App_Route(t *testing.T) {
 	resp, err = app.Test(httptest.NewRequest(MethodGet, "/test/v1/v2/v3", nil))
 	require.NoError(t, err, "app.Test(req)")
 	require.Equal(t, 200, resp.StatusCode, "Status code")
+}
+
+func Test_App_Route(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+
+	app.Route("/test", func(api Router) {
+		api.Get("/foo", testEmptyHandler).Name("foo")
+
+		api.Route("/bar", func(bar Router) {
+			bar.Get("/", testEmptyHandler).Name("index")
+		}, "bar.")
+	}, "test.")
+
+	testStatus200(t, app, "/test/foo", MethodGet)
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/test/bar/", nil))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, http.StatusOK, resp.StatusCode, "Status code")
+
+	require.Equal(t, "/test/foo", app.GetRoute("test.foo").Path)
+	require.Equal(t, "/test/bar/", app.GetRoute("test.bar.index").Path)
+}
+
+func Test_App_Route_nilFuncPanics(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+
+	require.PanicsWithValue(t, "route handler 'fn' cannot be nil", func() {
+		app.Route("/panic", nil)
+	})
+}
+
+func Test_Group_Route_nilFuncPanics(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	grp := app.Group("/api")
+
+	require.PanicsWithValue(t, "route handler 'fn' cannot be nil", func() {
+		grp.Route("/panic", nil)
+	})
+}
+
+func Test_Group_RouteChain_All(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	var calls []string
+	grp := app.Group("/api", func(c Ctx) error {
+		calls = append(calls, "group")
+		return c.Next()
+	})
+
+	grp.RouteChain("/users").All(func(c Ctx) error {
+		calls = append(calls, "routechain")
+		return c.SendStatus(http.StatusOK)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(MethodGet, "/api/users", nil))
+	require.NoError(t, err, "app.Test(req)")
+	require.Equal(t, http.StatusOK, resp.StatusCode, "Status code")
+	require.Equal(t, []string{"group", "routechain"}, calls)
 }
 
 func Test_App_Deep_Group(t *testing.T) {

--- a/binder/query.go
+++ b/binder/query.go
@@ -1,7 +1,7 @@
 package binder
 
 import (
-	utils "github.com/gofiber/utils/v2"
+	"github.com/gofiber/utils/v2"
 	"github.com/valyala/fasthttp"
 )
 

--- a/binder/query.go
+++ b/binder/query.go
@@ -18,19 +18,12 @@ func (*QueryBinding) Name() string {
 // Bind parses the request query and returns the result.
 func (b *QueryBinding) Bind(reqCtx *fasthttp.Request, out any) error {
 	data := make(map[string][]string)
-	var err error
-
 	for key, val := range reqCtx.URI().QueryArgs().All() {
 		k := utils.UnsafeString(key)
 		v := utils.UnsafeString(val)
-		err = formatBindData(b.Name(), out, data, k, v, b.EnableSplitting, true)
-		if err != nil {
-			break
+		if err := formatBindData(b.Name(), out, data, k, v, b.EnableSplitting, true); err != nil {
+			return err
 		}
-	}
-
-	if err != nil {
-		return err
 	}
 
 	return parse(b.Name(), out, data)

--- a/client/hooks.go
+++ b/client/hooks.go
@@ -258,7 +258,7 @@ func parserRequestBodyFile(req *Request) error {
 
 	// Add files.
 	fileBuf, ok := fileBufPool.Get().(*[]byte)
-	if !ok || len(*fileBuf) == 0 {
+	if !ok {
 		return errors.New("failed to retrieve buffer from a sync.Pool")
 	}
 

--- a/client/hooks.go
+++ b/client/hooks.go
@@ -261,10 +261,7 @@ func parserRequestBodyFile(req *Request) error {
 		return fmt.Errorf("failed to retrieve buffer from a sync.Pool")
 	}
 
-	defer func() {
-		b := (*fileBuf)[:cap(*fileBuf)] // set len to full cap for reuse in io.CopyBuffer
-		fileBufPool.Put(&b)
-	}()
+	defer fileBufPool.Put(fileBuf)
 
 	for i, v := range req.files {
 		if v.name == "" && v.path == "" {

--- a/client/hooks.go
+++ b/client/hooks.go
@@ -21,7 +21,8 @@ var protocolCheck = regexp.MustCompile(`^https?://.*$`)
 
 var fileBufPool = sync.Pool{
 	New: func() any {
-		return make([]byte, 1<<20) // 1MB buffer
+		b := make([]byte, 1<<20) // 1MB buffer
+		return &b
 	},
 }
 
@@ -256,8 +257,8 @@ func parserRequestBodyFile(req *Request) error {
 	}
 
 	// Add files.
-	fileBuf, ok := fileBufPool.Get().([]byte)
-	if !ok || len(fileBuf) == 0 {
+	fileBuf, ok := fileBufPool.Get().(*[]byte)
+	if !ok || len(*fileBuf) == 0 {
 		return errors.New("failed to retrieve buffer from a sync.Pool")
 	}
 
@@ -293,7 +294,7 @@ func parserRequestBodyFile(req *Request) error {
 			return fmt.Errorf("create file error: %w", err)
 		}
 
-		if _, err := io.CopyBuffer(w, v.reader, fileBuf); err != nil {
+		if _, err := io.CopyBuffer(w, v.reader, *fileBuf); err != nil {
 			return fmt.Errorf("failed to copy file data: %w", err)
 		}
 

--- a/client/hooks.go
+++ b/client/hooks.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -258,7 +259,7 @@ func parserRequestBodyFile(req *Request) error {
 	// Add files.
 	fileBuf, ok := fileBufPool.Get().(*[]byte)
 	if !ok || len(*fileBuf) == 0 {
-		return fmt.Errorf("failed to retrieve buffer from a sync.Pool")
+		return errors.New("failed to retrieve buffer from a sync.Pool")
 	}
 
 	defer fileBufPool.Put(fileBuf)

--- a/client/hooks.go
+++ b/client/hooks.go
@@ -21,8 +21,7 @@ var protocolCheck = regexp.MustCompile(`^https?://.*$`)
 
 var fileBufPool = sync.Pool{
 	New: func() any {
-		b := make([]byte, 1<<20) // 1MB buffer
-		return &b
+		return make([]byte, 1<<20) // 1MB buffer
 	},
 }
 
@@ -257,8 +256,8 @@ func parserRequestBodyFile(req *Request) error {
 	}
 
 	// Add files.
-	fileBuf, ok := fileBufPool.Get().(*[]byte)
-	if !ok || len(*fileBuf) == 0 {
+	fileBuf, ok := fileBufPool.Get().([]byte)
+	if !ok || len(fileBuf) == 0 {
 		return errors.New("failed to retrieve buffer from a sync.Pool")
 	}
 
@@ -294,7 +293,7 @@ func parserRequestBodyFile(req *Request) error {
 			return fmt.Errorf("create file error: %w", err)
 		}
 
-		if _, err := io.CopyBuffer(w, v.reader, *fileBuf); err != nil {
+		if _, err := io.CopyBuffer(w, v.reader, fileBuf); err != nil {
 			return fmt.Errorf("failed to copy file data: %w", err)
 		}
 

--- a/client/hooks_test.go
+++ b/client/hooks_test.go
@@ -709,6 +709,11 @@ func Benchmark_Parser_Request_Body_File(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
+		var totalBytes int64
+		for _, c := range fileContents {
+			totalBytes += int64(len(c))
+		}
+		b.SetBytes(totalBytes)
 		req := newBenchmarkRequest(formValues, fileContents)
 		if err := parserRequestBodyFile(req); err != nil {
 			b.Fatalf("parserRequestBodyFile: %v", err)

--- a/client/hooks_test.go
+++ b/client/hooks_test.go
@@ -732,11 +732,11 @@ func newBenchmarkRequest(formValues map[string]string, fileContents [][]byte) *R
 	}
 
 	for i, content := range fileContents {
-		req.files[i] = &File{
-			name:      fmt.Sprintf("file-%d.bin", i),
-			fieldName: fmt.Sprintf("file%d", i),
-			reader:    io.NopCloser(bytes.NewReader(content)),
-		}
+		req.files[i] = AcquireFile(
+			SetFileName(fmt.Sprintf("file-%d.bin", i)),
+			SetFileFieldName(fmt.Sprintf("file%d", i)),
+			SetFileReader(io.NopCloser(bytes.NewReader(content))),
+		)
 	}
 
 	return req
@@ -745,4 +745,7 @@ func newBenchmarkRequest(formValues map[string]string, fileContents [][]byte) *R
 func releaseBenchmarkRequest(req *Request) {
 	fasthttp.ReleaseRequest(req.RawRequest)
 	fasthttp.ReleaseArgs(req.formData.Args)
+	for _, f := range req.files {
+		ReleaseFile(f)
+	}
 }

--- a/client/hooks_test.go
+++ b/client/hooks_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
 )
 
 func Test_Rand_String(t *testing.T) {
@@ -685,4 +686,63 @@ func Test_Client_Logger_DisableDebug(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Empty(t, buf.String())
+}
+
+func Benchmark_Parser_Request_Body_File(b *testing.B) {
+	b.Helper()
+
+	const (
+		fileCount = 3
+		fileSize  = 32 << 10 // 32KB payload per file
+	)
+
+	formValues := map[string]string{
+		"username": "fiber",
+		"api_key":  "d5942ef5",
+	}
+
+	fileContents := make([][]byte, fileCount)
+	for i := range fileContents {
+		fileContents[i] = bytes.Repeat([]byte{byte('a' + i)}, fileSize)
+	}
+
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		req := newBenchmarkRequest(formValues, fileContents)
+		if err := parserRequestBodyFile(req); err != nil {
+			b.Fatalf("parserRequestBodyFile: %v", err)
+		}
+		releaseBenchmarkRequest(req)
+	}
+}
+
+func newBenchmarkRequest(formValues map[string]string, fileContents [][]byte) *Request {
+	req := &Request{
+		boundary:   "FiberBenchmarkBoundary",
+		formData:   &FormData{Args: fasthttp.AcquireArgs()},
+		RawRequest: fasthttp.AcquireRequest(),
+		files:      make([]*File, len(fileContents)),
+	}
+
+	req.RawRequest.Header.SetContentType("multipart/form-data; boundary=" + req.boundary)
+
+	for key, value := range formValues {
+		req.formData.Set(key, value)
+	}
+
+	for i, content := range fileContents {
+		req.files[i] = &File{
+			name:      fmt.Sprintf("file-%d.bin", i),
+			fieldName: fmt.Sprintf("file%d", i),
+			reader:    io.NopCloser(bytes.NewReader(content)),
+		}
+	}
+
+	return req
+}
+
+func releaseBenchmarkRequest(req *Request) {
+	fasthttp.ReleaseRequest(req.RawRequest)
+	fasthttp.ReleaseArgs(req.formData.Args)
 }

--- a/client/request.go
+++ b/client/request.go
@@ -218,6 +218,9 @@ func (r *Request) Param(key string) []string {
 func (r *Request) Params() iter.Seq2[string, []string] {
 	return func(yield func(string, []string) bool) {
 		vals := r.params.Len()
+		if vals == 0 {
+			return
+		}
 		prealloc := make([]string, 2*vals)
 		p := pair{
 			k: prealloc[:0:vals],
@@ -454,6 +457,9 @@ func (r *Request) FormData(key string) []string {
 func (r *Request) AllFormData() iter.Seq2[string, []string] {
 	return func(yield func(string, []string) bool) {
 		vals := r.formData.Len()
+		if vals == 0 {
+			return
+		}
 		prealloc := make([]string, 2*vals)
 		p := pair{
 			k: prealloc[:0:vals],

--- a/client/request.go
+++ b/client/request.go
@@ -218,9 +218,10 @@ func (r *Request) Param(key string) []string {
 func (r *Request) Params() iter.Seq2[string, []string] {
 	return func(yield func(string, []string) bool) {
 		vals := r.params.Len()
+		prealloc := make([]string, 2*vals)
 		p := pair{
-			k: make([]string, 0, vals),
-			v: make([]string, 0, vals),
+			k: prealloc[:0:vals],
+			v: prealloc[vals : vals : 2*vals],
 		}
 		for k, v := range r.params.All() {
 			p.k = append(p.k, utils.UnsafeString(k))

--- a/client/request.go
+++ b/client/request.go
@@ -454,9 +454,10 @@ func (r *Request) FormData(key string) []string {
 func (r *Request) AllFormData() iter.Seq2[string, []string] {
 	return func(yield func(string, []string) bool) {
 		vals := r.formData.Len()
+		prealloc := make([]string, 2*vals)
 		p := pair{
-			k: make([]string, 0, vals),
-			v: make([]string, 0, vals),
+			k: prealloc[:0:vals],
+			v: prealloc[vals : vals : 2*vals],
 		}
 		for k, v := range r.formData.All() {
 			p.k = append(p.k, utils.UnsafeString(k))

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -322,19 +322,44 @@ func Test_Request_QueryParam(t *testing.T) {
 func Test_Request_Params(t *testing.T) {
 	t.Parallel()
 
-	req := AcquireRequest()
-	req.AddParams(map[string][]string{
-		"foo": {"bar", "fiber"},
-		"bar": {"foo"},
+	t.Run("empty iterator", func(t *testing.T) {
+		t.Parallel()
+
+		req := AcquireRequest()
+		t.Cleanup(func() {
+			ReleaseRequest(req)
+		})
+
+		called := false
+		req.Params()(func(_ string, _ []string) bool {
+			called = true
+			return true
+		})
+
+		require.False(t, called)
 	})
 
-	pathParams := maps.Collect(req.Params())
+	t.Run("populated iterator", func(t *testing.T) {
+		t.Parallel()
 
-	require.Contains(t, pathParams["foo"], "bar")
-	require.Contains(t, pathParams["foo"], "fiber")
-	require.Contains(t, pathParams["bar"], "foo")
+		req := AcquireRequest()
+		t.Cleanup(func() {
+			ReleaseRequest(req)
+		})
 
-	require.Len(t, pathParams, 2)
+		req.AddParams(map[string][]string{
+			"foo": {"bar", "fiber"},
+			"bar": {"foo"},
+		})
+
+		pathParams := maps.Collect(req.Params())
+
+		require.Contains(t, pathParams["foo"], "bar")
+		require.Contains(t, pathParams["foo"], "fiber")
+		require.Contains(t, pathParams["bar"], "foo")
+
+		require.Len(t, pathParams, 2)
+	})
 }
 
 func Benchmark_Request_Params(b *testing.B) {
@@ -1373,19 +1398,44 @@ func Test_Request_Body_With_Server(t *testing.T) {
 func Test_Request_AllFormData(t *testing.T) {
 	t.Parallel()
 
-	req := AcquireRequest()
-	req.AddFormDataWithMap(map[string][]string{
-		"foo": {"bar", "fiber"},
-		"bar": {"foo"},
+	t.Run("empty iterator", func(t *testing.T) {
+		t.Parallel()
+
+		req := AcquireRequest()
+		t.Cleanup(func() {
+			ReleaseRequest(req)
+		})
+
+		called := false
+		req.AllFormData()(func(_ string, _ []string) bool {
+			called = true
+			return true
+		})
+
+		require.False(t, called)
 	})
 
-	pathParams := maps.Collect(req.AllFormData())
+	t.Run("populated iterator", func(t *testing.T) {
+		t.Parallel()
 
-	require.Contains(t, pathParams["foo"], "bar")
-	require.Contains(t, pathParams["foo"], "fiber")
-	require.Contains(t, pathParams["bar"], "foo")
+		req := AcquireRequest()
+		t.Cleanup(func() {
+			ReleaseRequest(req)
+		})
 
-	require.Len(t, pathParams, 2)
+		req.AddFormDataWithMap(map[string][]string{
+			"foo": {"bar", "fiber"},
+			"bar": {"foo"},
+		})
+
+		pathParams := maps.Collect(req.AllFormData())
+
+		require.Contains(t, pathParams["foo"], "bar")
+		require.Contains(t, pathParams["foo"], "fiber")
+		require.Contains(t, pathParams["bar"], "foo")
+
+		require.Len(t, pathParams, 2)
+	})
 }
 
 func Benchmark_Request_AllFormData(b *testing.B) {

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -138,14 +138,14 @@ func handler(c fiber.Ctx) error {
 }
 ```
 
-### Route
+### RouteChain
 
 Returns an instance of a single route, which you can then use to handle HTTP verbs with optional middleware.
 
-Similar to [`Express`](https://expressjs.com/de/api.html#app.route).
+Similar to [`Express`](https://expressjs.com/en/api.html#app.route).
 
 ```go title="Signature"
-func (app *App) Route(path string) Register
+func (app *App) RouteChain(path string) Register
 ```
 
 <details>
@@ -166,7 +166,7 @@ type Register interface {
 
     Add(methods []string, handler Handler, handlers ...Handler) Register
 
-    Route(path string) Register
+    RouteChain(path string) Register
 }
 ```
 
@@ -184,12 +184,12 @@ import (
 func main() {
     app := fiber.New()
 
-    // Use `Route` as a chainable route declaration method
-    app.Route("/test").Get(func(c fiber.Ctx) error {
+    // Use `RouteChain` as a chainable route declaration method
+    app.RouteChain("/test").Get(func(c fiber.Ctx) error {
         return c.SendString("GET /test")
     })
 
-    app.Route("/events").All(func(c fiber.Ctx) error {
+    app.RouteChain("/events").All(func(c fiber.Ctx) error {
         // Runs for all HTTP verbs first
         // Think of it as route-specific middleware!
     }).
@@ -202,12 +202,12 @@ func main() {
     })
 
     // Combine multiple routes
-    app.Route("/v2").Route("/user").Get(func(c fiber.Ctx) error {
-        return c.SendString("GET /v2/user")
+    app.RouteChain("/reports").RouteChain("/daily").Get(func(c fiber.Ctx) error {
+        return c.SendString("GET /reports/daily")
     })
 
     // Use multiple methods
-    app.Route("/api").Get(func(c fiber.Ctx) error {
+    app.RouteChain("/api").Get(func(c fiber.Ctx) error {
         return c.SendString("GET /api")
     }).Post(func(c fiber.Ctx) error {
         return c.SendString("POST /api")
@@ -215,6 +215,21 @@ func main() {
 
     log.Fatal(app.Listen(":3000"))
 }
+```
+
+### Route
+
+Defines routes with a common prefix inside the supplied function. Internally it uses [`Group`](#group) to create a sub-router and accepts an optional name prefix.
+
+```go title="Signature"
+func (app *App) Route(prefix string, fn func(router Router), name ...string) Router
+```
+
+```go title="Example"
+app.Route("/test", func(api fiber.Router) {
+    api.Get("/foo", handler).Name("foo") // /test/foo (name: test.foo)
+    api.Get("/bar", handler).Name("bar") // /test/bar (name: test.bar)
+}, "test.")
 ```
 
 ### HandlersCount

--- a/docs/middleware/cache.md
+++ b/docs/middleware/cache.md
@@ -104,6 +104,8 @@ app.Use(cache.New(cache.Config{
 
 `CacheInvalidator` defines custom invalidation rules. Return `true` to bypass the cache. In the example above, setting the `invalidateCache` query parameter to `true` invalidates the entry.
 
+Cache keys are masked in logs and error messages by default. Set `DisableValueRedaction` to `true` if you explicitly need the raw key for debugging.
+
 ## Config
 
 | Property             | Type                                           | Description                                                                                                                                                                                                                                                                                                    | Default                                                          |
@@ -113,6 +115,7 @@ app.Use(cache.New(cache.Config{
 | CacheHeader          | `string`                                       | CacheHeader is the header on the response header that indicates the cache status, with the possible return values "hit," "miss," or "unreachable."                                                                                                                                                             | `X-Cache`                                                        |
 | DisableCacheControl  | `bool`                                          | DisableCacheControl omits the `Cache-Control` header when set to `true`. | `false`                                                         |
 | CacheInvalidator     | `func(fiber.Ctx) bool`                         | CacheInvalidator defines a function that is executed before checking the cache entry. It can be used to invalidate the existing cache manually by returning true. | `nil`                                                            |
+| DisableValueRedaction | `bool`                                        | Turns off cache key redaction in logs and error messages when set to `true`. | `false`                                             |
 | KeyGenerator         | `func(fiber.Ctx) string`                       | KeyGenerator allows you to generate custom keys. The HTTP method is appended automatically. | `func(c fiber.Ctx) string { return utils.CopyString(c.Path()) }` |
 | ExpirationGenerator  | `func(fiber.Ctx, *cache.Config) time.Duration` | ExpirationGenerator allows you to generate custom expiration keys based on the request.                                                                                                                                                                                                                        | `nil`                                                            |
 | Storage              | `fiber.Storage`                                | Storage is used to store the state of the middleware.                                                                                                                                                                                                                                                            | In-memory store                                                  |
@@ -129,6 +132,7 @@ var ConfigDefault = Config{
     CacheHeader:  "X-Cache",
     DisableCacheControl: false,
     CacheInvalidator: nil,
+    DisableValueRedaction: false,
     KeyGenerator: func(c fiber.Ctx) string {
         return utils.CopyString(c.Path())
     },

--- a/docs/middleware/cors.md
+++ b/docs/middleware/cors.md
@@ -10,7 +10,7 @@ It adds CORS headers to responses, listing allowed origins, methods, and headers
 
 Use the `AllowOrigins` option to define which origins may send cross-origin requests. It accepts single origins, lists, subdomain patterns, wildcards, and supports dynamic validation with `AllowOriginsFunc`.
 
-The middleware normalizes `AllowOrigins`, verifies HTTP/HTTPS schemes, and strips trailing slashes. Invalid origins cause a panic.
+The middleware normalizes `AllowOrigins`, verifies HTTP/HTTPS schemes, and strips trailing slashes. Invalid origins cause a panic. Panic messages and logs redact misconfigured origins by default; set `DisableValueRedaction` to `true` if you need the raw value for troubleshooting.
 
 Avoid [common pitfalls](#common-pitfalls) such as using wildcard origins with credentials, overly permissive origin lists, or skipping validation with `AllowOriginsFunc`, as misconfiguration can create security risks.
 
@@ -118,6 +118,7 @@ panic: [CORS] Configuration error: When 'AllowCredentials' is set to true, 'Allo
 | AllowOrigins         | `[]string`                  | AllowOrigins defines a list of origins that may access the resource. This supports subdomain matching, so you can use a value like "https://*.example.com" to allow any subdomain of example.com to submit requests. If the special wildcard `"*"` is present in the list, all origins will be allowed.                                                              | `["*"]`                                 |
 | AllowOriginsFunc     | `func(origin string) bool`  | `AllowOriginsFunc` is a function that dynamically determines whether to allow a request based on its origin. If this function returns `true`, the 'Access-Control-Allow-Origin' response header will be set to the request's 'origin' header. This function is only used if the request's origin doesn't match any origin in `AllowOrigins`.                         | `nil`                                   |
 | AllowPrivateNetwork  | `bool`                      | Indicates whether the `Access-Control-Allow-Private-Network` response header should be set to `true`, allowing requests from private networks. This aligns with modern security practices for web applications interacting with private networks.                                                                                                                    | `false`                                 |
+| DisableValueRedaction | `bool`                    | Disables redaction of misconfigured origins and settings in panics and logs. | `false`                                 |
 | ExposeHeaders        | `[]string`                    | ExposeHeaders defines an allowlist of headers that clients are allowed to access.                                                                                                                                                                                                                                                                                    | `[]`                                    |
 | MaxAge               | `int`                       | MaxAge indicates how long (in seconds) the results of a preflight request can be cached. If you pass MaxAge 0, the Access-Control-Max-Age header will not be added and the browser will use 5 seconds by default. To disable caching completely, pass MaxAge value negative. It will set the Access-Control-Max-Age header to 0.                                     | `0`                                     |
 | Next                 | `func(fiber.Ctx) bool`      | Next defines a function to skip this middleware when it returns true.                                                                                                                                                                                                                                                                                                  | `nil`                                   |
@@ -133,6 +134,7 @@ var ConfigDefault = Config{
     Next:             nil,
     AllowOriginsFunc: nil,
     AllowOrigins:     []string{"*"},
+    DisableValueRedaction: false,
     AllowMethods: []string{
         fiber.MethodGet,
         fiber.MethodPost,

--- a/docs/middleware/csrf.md
+++ b/docs/middleware/csrf.md
@@ -42,6 +42,8 @@ app.Use(csrf.New(csrf.Config{
     CookieSessionOnly: true,
     Extractor:         extractors.FromHeader("X-Csrf-Token"),
     Session:           sessionStore,
+    // Redaction is enabled by default. Set DisableValueRedaction when you must expose tokens or storage keys in diagnostics.
+    // DisableValueRedaction: true,
 }))
 ```
 
@@ -403,6 +405,7 @@ func (h *csrf.Handler) DeleteToken(c fiber.Ctx) error
 | KeyGenerator      | `func() string`                    | Token generation function                                                                                                     | `utils.UUIDv4`               |
 | ErrorHandler      | `fiber.ErrorHandler`               | Custom error handler                                                                                                          | `defaultErrorHandler`        |
 | Extractor         | `extractors.Extractor`             | Token extraction method with metadata                                                                                         | `extractors.FromHeader("X-Csrf-Token")` |
+| DisableValueRedaction | `bool`                         | Disables redaction of tokens and storage keys in logs and error messages. | `false`                      |
 | Session           | `*session.Store`                   | Session store (**recommended for production**)                                                                                | `nil`                        |
 | Storage           | `fiber.Storage`                    | Token storage (overridden by Session)                                                                                         | `nil`                        |
 | TrustedOrigins    | `[]string`                         | Trusted origins for cross-origin requests                                                                                     | `[]`                         |

--- a/docs/middleware/idempotency.md
+++ b/docs/middleware/idempotency.md
@@ -68,6 +68,8 @@ app.Use(idempotency.New(idempotency.Config{
 
 ## Config
 
+Idempotency keys are hidden in logs and error messages by default. Set `DisableValueRedaction` to `true` only when you need to expose them for debugging.
+
 | Property            | Type                   | Description                                                                                                                             | Default                                                            |
 |:--------------------|:-----------------------|:----------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------|
 | Next                | `func(fiber.Ctx) bool` | Function to skip this middleware when it returns `true`; use `IsMethodSafe` or `IsMethodIdempotent`. | `func(c fiber.Ctx) bool { return fiber.IsMethodSafe(c.Method()) }` |
@@ -75,6 +77,7 @@ app.Use(idempotency.New(idempotency.Config{
 | KeyHeader           | `string`               | Header name containing the idempotency key.                                                                                             | `"X-Idempotency-Key"`                                              |
 | KeyHeaderValidate   | `func(string) error`   | Function to validate idempotency header syntax (e.g., UUID).                                                                            | UUID length check (`36` characters)                                |
 | KeepResponseHeaders | `[]string`             | List of headers to preserve from original response.                                                                                     | `nil` (keep all headers)                                           |
+| DisableValueRedaction | `bool`                | Disables idempotency key redaction in logs and error messages. | `false`                                              |
 | Lock                | `Locker`               | Locks an idempotency key to prevent race conditions.                                                                                    | In-memory locker                                                   |
 | Storage             | `fiber.Storage`        | Stores response data by idempotency key.                                                                                                | In-memory storage                                                  |
 
@@ -103,5 +106,6 @@ var ConfigDefault = Config{
     Lock: nil, // Set in configDefault so we don't allocate data here.
 
     Storage: nil, // Set in configDefault so we don't allocate data here.
+    DisableValueRedaction: false,
 }
 ```

--- a/docs/middleware/limiter.md
+++ b/docs/middleware/limiter.md
@@ -6,6 +6,8 @@ id: limiter
 
 The Limiter middleware for [Fiber](https://github.com/gofiber/fiber) throttles repeated requests to public APIs or endpoints such as password resets. It's also useful for API clients, web crawlers, or other tasks that need rate limiting.
 
+Limiter redacts request keys in error paths by default so storage identifiers and rate-limit keys don't leak into logs. Set `DisableValueRedaction` to `true` when you explicitly need the raw key for troubleshooting.
+
 :::note
 This middleware uses our [Storage](https://github.com/gofiber/storage) package to support various databases through a single interface. The default configuration for this middleware saves data to memory, see the examples below for other databases.
 :::
@@ -106,6 +108,7 @@ app.Use(limiter.New(limiter.Config{
 | SkipFailedRequests     | `bool`                    | When set to `true`, requests with status code ≥ 400 aren't counted.                         | false                                    |
 | SkipSuccessfulRequests | `bool`                    | When set to `true`, requests with status code < 400 aren't counted.                          | false                                    |
 | DisableHeaders         | `bool`                    | When set to `true`, the middleware omits rate limit headers (`X-RateLimit-*` and `Retry-After`). | false                                    |
+| DisableValueRedaction  | `bool`                    | Disables redaction of limiter keys in error messages and logs.                                 | false                                    |
 | Storage                | `fiber.Storage`           | Persists middleware state.                                         | An in-memory store for this process only |
 | LimiterMiddleware      | `LimiterHandler`          | Selects the algorithm implementation.                       | A new Fixed Window Rate Limiter          |
 
@@ -131,6 +134,7 @@ var ConfigDefault = Config{
     SkipFailedRequests: false,
     SkipSuccessfulRequests: false,
     DisableHeaders:        false,
+    DisableValueRedaction: false,
     LimiterMiddleware: FixedWindow{},
 }
 ```

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1161,6 +1161,8 @@ We are excited to introduce a new option in our caching middleware: Cache Invali
 Additionally, the caching middleware has been optimized to avoid caching non-cacheable status codes, as defined by the [HTTP standards](https://datatracker.ietf.org/doc/html/rfc7231#section-6.1). This improvement enhances cache accuracy and reduces unnecessary cache storage usage.
 Cached responses now include an RFC-compliant Age header, providing a standardized indication of how long a response has been stored in cache since it was originally generated. This enhancement improves HTTP compliance and facilitates better client-side caching strategies.
 
+Cache keys are now redacted in logs and error messages by default, and a `DisableValueRedaction` boolean (default `false`) lets you opt out when you need the raw value for troubleshooting.
+
 :::note
 The deprecated `Store` and `Key` options have been removed in v3. Use `Storage` and `KeyGenerator` instead.
 :::
@@ -1182,6 +1184,8 @@ We've updated several fields from a single string (containing comma-separated va
 - `Config.AllowHeaders`: Now accepts a slice of strings, each representing an allowed header.
 - `Config.ExposeHeaders`: Now accepts a slice of strings, each representing an exposed header.
 
+Additionally, panic messages and logs redact misconfigured origins by default, and a `DisableValueRedaction` flag (default `false`) lets you reveal them when necessary.
+
 ### Compression
 
 - Added support for `zstd` compression alongside `gzip`, `deflate`, and `brotli`.
@@ -1193,6 +1197,12 @@ We've updated several fields from a single string (containing comma-separated va
 ### CSRF
 
 The `Expiration` field in the CSRF middleware configuration has been renamed to `IdleTimeout` to better describe its functionality. Additionally, the default value has been reduced from 1 hour to 30 minutes.
+
+CSRF now redacts tokens and storage keys by default and exposes a `DisableValueRedaction` toggle (default `false`) if you must surface those values in diagnostics.
+
+### Idempotency
+
+Idempotency middleware now redacts keys by default and offers a `DisableValueRedaction` configuration flag (default `false`) to expose them when debugging.
 
 ### EncryptCookie
 
@@ -1383,6 +1393,8 @@ See more in [Logger](./middleware/logger.md#predefined-formats)
 ### Limiter
 
 The limiter middleware uses a new Fixed Window Rate Limiter implementation.
+
+Limiter now redacts request keys in error paths by default. A new `DisableValueRedaction` boolean (default `false`) lets you reveal the raw limiter key if diagnostics require it.
 
 :::note
 Deprecated fields `Duration`, `Store`, and `Key` have been removed in v3. Use `Expiration`, `Storage`, and `KeyGenerator` instead.
@@ -2212,6 +2224,7 @@ app.Use(csrf.New(csrf.Config{
 - **Session Key Removal**: The `SessionKey` field has been removed from the CSRF middleware configuration. The session key is now an unexported constant within the middleware to avoid potential key collisions in the session store.
 
 - **KeyLookup Field Removal**: The `KeyLookup` field has been removed from the CSRF middleware configuration. This field was deprecated and is no longer needed as the middleware now uses a more secure approach for token management.
+- **DisableValueRedaction Toggle**: CSRF redacts tokens and storage keys by default; set `DisableValueRedaction` to `true` when diagnostics require the raw values.
 
 ```go
 // Before
@@ -2246,6 +2259,10 @@ app.Use(csrf.New(csrf.Config{
 ```
 
 **Security Note**: The removal of `FromCookie` prevents a common misconfiguration that would completely bypass CSRF protection. The middleware uses the Double Submit Cookie pattern, which requires the token to be submitted through a different channel than the cookie to provide meaningful protection.
+
+#### Idempotency
+
+- **DisableValueRedaction Toggle**: The idempotency middleware now hides keys in logs and error paths by default, with a `DisableValueRedaction` boolean (default `false`) to reveal them when needed.
 
 #### Timeout
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -328,18 +328,17 @@ In `v2` one handler was already mandatory when the route has been registered, bu
 
 ### Route chaining
 
-The route method is now like [`Express`](https://expressjs.com/de/api.html#app.route) which gives you the option of a different notation and allows you to concatenate the route declaration.
+This release introduces a dedicated `RouteChain` helper, inspired by [`Express`](https://expressjs.com/en/api.html#app.route), for declaring a stack of handlers on the same path. The original `Route` helper for prefix encapsulation also remains available.
 
-```diff
--    Route(prefix string, fn func(router Router), name ...string) Router
-+    Route(path string) Register
+```go
+RouteChain(path string) Register
 ```
 
 <details>
 <summary>Example</summary>
 
 ```go
-app.Route("/api").Route("/user/:id?")
+app.RouteChain("/api").RouteChain("/user/:id?")
     .Get(func(c fiber.Ctx) error {
         // Get user
         return c.JSON(fiber.Map{"message": "Get user", "id": c.Params("id")})
@@ -360,11 +359,11 @@ app.Route("/api").Route("/user/:id?")
 
 </details>
 
-You can find more information about `app.Route` in the [API documentation](./api/app#route).
+You can find more information about `app.RouteChain` and `app.Route` in the API documentation ([RouteChain](./api/app#routechain), [Route](./api/app#route)).
 
 ### Middleware registration
 
-We have aligned our method for middlewares closer to [`Express`](https://expressjs.com/de/api.html#app.use) and now also support the [`Use`](./api/app#use) of multiple prefixes.
+We have aligned our method for middlewares closer to [`Express`](https://expressjs.com/en/api.html#app.use) and now also support the [`Use`](./api/app#use) of multiple prefixes.
 
 Prefix matching is now stricter: partial matches must end at a slash boundary (or be an exact match). This keeps `/api` middleware from running on `/apiv1` while still allowing `/api/:version` style patterns that leverage route parameters, optional segments, or wildcards.
 
@@ -1653,7 +1652,7 @@ app.Add([]string{fiber.MethodPost}, "/api", myHandler)
 
 #### Mounting
 
-In Fiber v3, the `Mount` method has been removed. Instead, you can use the `Use` method to achieve similar functionality.
+In this release, the `Mount` method has been removed. Instead, you can use the `Use` method to achieve similar functionality.
 
 ```go
 // Before
@@ -1667,7 +1666,7 @@ app.Use("/api", apiApp)
 
 #### Route Chaining
 
-Refer to the [route chaining](#route-chaining) section for details on migrating `Route`.
+Refer to the [route chaining](#route-chaining) section for details on the new `RouteChain` helper. The `Route` function now matches its v2 behavior for prefix encapsulation.
 
 ```go
 // Before
@@ -1687,7 +1686,7 @@ app.Route("/api", func(apiGrp Router) {
 
 ```go
 // After
-app.Route("/api").Route("/user/:id?")
+app.RouteChain("/api").RouteChain("/user/:id?")
     .Get(func(c fiber.Ctx) error {
         // Get user
         return c.JSON(fiber.Map{"message": "Get user", "id": c.Params("id")})

--- a/group.go
+++ b/group.go
@@ -196,11 +196,30 @@ func (grp *Group) Group(prefix string, handlers ...Handler) Router {
 	return newGrp
 }
 
-// Route is used to define routes with a common prefix inside the common function.
-// Uses Group method to define new sub-router.
-func (grp *Group) Route(path string) Register {
+// RouteChain creates a Registering instance scoped to the group's prefix,
+// allowing chained route declarations for the same path.
+func (grp *Group) RouteChain(path string) Register {
 	// Create new group
-	register := &Registering{app: grp.app, path: getGroupPath(grp.Prefix, path)}
+	register := &Registering{app: grp.app, group: grp, path: getGroupPath(grp.Prefix, path)}
 
 	return register
+}
+
+// Route is used to define routes with a common prefix inside the supplied
+// function. It mirrors the legacy helper and reuses the Group method to create
+// a sub-router.
+func (grp *Group) Route(prefix string, fn func(router Router), name ...string) Router {
+	if fn == nil {
+		panic("route handler 'fn' cannot be nil")
+	}
+	// Create new group
+	group := grp.Group(prefix)
+	if len(name) > 0 {
+		group.Name(name[0])
+	}
+
+	// Define routes
+	fn(group)
+
+	return group
 }

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -86,6 +86,12 @@ func (s *Storage) gc(sleep time.Duration) {
 			}
 		}
 		s.RUnlock()
+
+		if len(expired) == 0 {
+			// avoid locking if nothing to delete
+			continue
+		}
+
 		s.Lock()
 		// Double-checked locking.
 		// We might have replaced the item in the meantime.

--- a/middleware/adaptor/adaptor.go
+++ b/middleware/adaptor/adaptor.go
@@ -169,7 +169,7 @@ func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 		}
 
 		// Determine remoteAddr for TCP or fallback for Unix sockets
-		var remoteAddr *net.TCPAddr
+		var remoteAddr net.Addr
 		tcpAddr, err := net.ResolveTCPAddr("tcp", r.RemoteAddr)
 		if err != nil {
 			// Unix socket or invalid address

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -760,7 +760,7 @@ func TestHandlerFunc_FallbackRemoteAddr(t *testing.T) {
 	handler := handlerFunc(app)
 
 	// Fake request with bad RemoteAddr
-	req, err := http.NewRequest("GET", "/", nil)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/", nil)
 	require.NoError(t, err)
 	req.RemoteAddr = "bad-addr"
 

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -760,7 +760,7 @@ func TestHandlerFunc_FallbackRemoteAddr(t *testing.T) {
 	handler := handlerFunc(app)
 
 	// Fake request with bad RemoteAddr
-	req, err := http.NewRequestWithContext(context.Background(), "GET", "/", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	require.NoError(t, err)
 	req.RemoteAddr = "bad-addr"
 

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -692,7 +692,7 @@ func TestUnixSocketAdaptor(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if closeErr := listener.Close(); err != nil {
+		if closeErr := listener.Close(); closeErr != nil {
 			t.Logf("listener close failed: %v", closeErr)
 		}
 	}()

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -714,7 +714,7 @@ func TestUnixSocketAdaptor(t *testing.T) {
 	conn, err := net.Dial("unix", socketPath)
 	require.NoError(t, err)
 	defer func() {
-		if closeErr := conn.Close(); err != nil {
+		if closeErr := conn.Close(); closeErr != nil {
 			t.Logf("conn close failed: %v", closeErr)
 		}
 	}()

--- a/middleware/adaptor/adaptor_test.go
+++ b/middleware/adaptor/adaptor_test.go
@@ -692,8 +692,8 @@ func TestUnixSocketAdaptor(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := listener.Close(); err != nil {
-			t.Logf("listener close failed: %v", err)
+		if closeErr := listener.Close(); err != nil {
+			t.Logf("listener close failed: %v", closeErr)
 		}
 	}()
 
@@ -714,8 +714,8 @@ func TestUnixSocketAdaptor(t *testing.T) {
 	conn, err := net.Dial("unix", socketPath)
 	require.NoError(t, err)
 	defer func() {
-		if err := conn.Close(); err != nil {
-			t.Logf("conn close failed: %v", err)
+		if closeErr := conn.Close(); err != nil {
+			t.Logf("conn close failed: %v", closeErr)
 		}
 	}()
 

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -71,6 +71,15 @@ func New(config ...Config) fiber.Handler {
 	// Set default config
 	cfg := configDefault(config...)
 
+	redactKeys := !cfg.DisableValueRedaction
+
+	maskKey := func(key string) string {
+		if redactKeys {
+			return redactedKey
+		}
+		return key
+	}
+
 	// Nothing to cache
 	if int(cfg.Expiration.Seconds()) < 0 {
 		return func(c fiber.Ctx) error {
@@ -84,7 +93,7 @@ func New(config ...Config) fiber.Handler {
 		timestamp = uint64(time.Now().Unix()) //nolint:gosec //Not a concern
 	)
 	// Create manager to simplify storage operations ( see manager.go )
-	manager := newManager(cfg.Storage)
+	manager := newManager(cfg.Storage, redactKeys)
 	// Create indexed heap for tracking expirations ( see heap.go )
 	heap := &indexedHeap{}
 	// count stored bytes (sizes of response bodies)
@@ -158,7 +167,7 @@ func New(config ...Config) fiber.Handler {
 						manager.release(e)
 					}
 					mux.Unlock()
-					return fmt.Errorf("cache: failed to delete expired key %q: %w", key, err)
+					return fmt.Errorf("cache: failed to delete expired key %q: %w", maskKey(key), err)
 				}
 				idx := e.heapidx
 				manager.release(e)
@@ -174,7 +183,7 @@ func New(config ...Config) fiber.Handler {
 					if err != nil {
 						manager.release(e)
 						mux.Unlock()
-						return cacheBodyFetchError(key, err)
+						return cacheBodyFetchError(maskKey, key, err)
 					}
 					e.body = rawBody
 				}
@@ -255,7 +264,7 @@ func New(config ...Config) fiber.Handler {
 			for storedBytes+bodySize > cfg.MaxBytes {
 				keyToRemove, size := heap.removeFirst()
 				if err := deleteKey(keyToRemove); err != nil {
-					return fmt.Errorf("cache: failed to delete key %q while evicting: %w", keyToRemove, err)
+					return fmt.Errorf("cache: failed to delete key %q while evicting: %w", maskKey(keyToRemove), err)
 				}
 				storedBytes -= size
 			}
@@ -323,7 +332,7 @@ func New(config ...Config) fiber.Handler {
 			if rawStored {
 				rawKey := key + "_body"
 				if err := manager.del(context.Background(), rawKey); err != nil {
-					cleanupErr = errors.Join(cleanupErr, fmt.Errorf("cache: failed to delete raw key %q after store error: %w", rawKey, err))
+					cleanupErr = errors.Join(cleanupErr, fmt.Errorf("cache: failed to delete raw key %q after store error: %w", maskKey(rawKey), err))
 				}
 			}
 			return cleanupErr
@@ -385,9 +394,9 @@ func hasRequestDirective(c fiber.Ctx, directive string) bool {
 	return false
 }
 
-func cacheBodyFetchError(key string, err error) error {
+func cacheBodyFetchError(mask func(string) string, key string, err error) error {
 	if errors.Is(err, errCacheMiss) {
-		return fmt.Errorf("cache: no cached body for key %q: %w", key, err)
+		return fmt.Errorf("cache: no cached body for key %q: %w", mask(key), err)
 	}
 	return err
 }

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -875,7 +875,7 @@ func Test_Cache_WithHead(t *testing.T) {
 		return c.SendString(strconv.Itoa(count))
 	}
 
-	app.Route("/").Get(handler).Head(handler)
+	app.RouteChain("/").Get(handler).Head(handler)
 
 	req := httptest.NewRequest(fiber.MethodHead, "/", nil)
 	resp, err := app.Test(req)
@@ -904,7 +904,7 @@ func Test_Cache_WithHeadThenGet(t *testing.T) {
 	handler := func(c fiber.Ctx) error {
 		return c.SendString(fiber.Query[string](c, "cache"))
 	}
-	app.Route("/").Get(handler).Head(handler)
+	app.RouteChain("/").Get(handler).Head(handler)
 
 	headResp, err := app.Test(httptest.NewRequest(fiber.MethodHead, "/?cache=123", nil))
 	require.NoError(t, err)

--- a/middleware/cache/config.go
+++ b/middleware/cache/config.go
@@ -62,6 +62,11 @@ type Config struct {
 	// Optional. Default: 1 * 1024 * 1024
 	MaxBytes uint
 
+	// DisableValueRedaction turns off masking cache keys in logs and error messages when set to true.
+	//
+	// Optional. Default: false
+	DisableValueRedaction bool
+
 	// DisableCacheControl disables client side caching if set to true
 	//
 	// Optional. Default: false
@@ -76,11 +81,12 @@ type Config struct {
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
-	Next:                nil,
-	Expiration:          5 * time.Minute,
-	CacheHeader:         "X-Cache",
-	DisableCacheControl: false,
-	CacheInvalidator:    nil,
+	Next:                  nil,
+	Expiration:            5 * time.Minute,
+	CacheHeader:           "X-Cache",
+	DisableCacheControl:   false,
+	CacheInvalidator:      nil,
+	DisableValueRedaction: false,
 	KeyGenerator: func(c fiber.Ctx) string {
 		return utils.CopyString(c.Path())
 	},

--- a/middleware/cache/manager_test.go
+++ b/middleware/cache/manager_test.go
@@ -12,7 +12,7 @@ import (
 
 func Test_manager_get(t *testing.T) {
 	t.Parallel()
-	cacheManager := newManager(nil)
+	cacheManager := newManager(nil, true)
 	t.Run("Item not found in cache", func(t *testing.T) {
 		t.Parallel()
 		it, err := cacheManager.get(context.Background(), utils.UUID())
@@ -29,4 +29,14 @@ func Test_manager_get(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, it)
 	})
+}
+
+func Test_manager_logKey(t *testing.T) {
+	t.Parallel()
+
+	redactedManager := newManager(nil, true)
+	assert.Equal(t, redactedKey, redactedManager.logKey("secret"))
+
+	plainManager := newManager(nil, false)
+	assert.Equal(t, "secret", plainManager.logKey("secret"))
 }

--- a/middleware/cors/config.go
+++ b/middleware/cors/config.go
@@ -56,6 +56,11 @@ type Config struct {
 	// Optional. Default value 0.
 	MaxAge int
 
+	// DisableValueRedaction turns off redaction of configuration values and origins in logs and panics.
+	//
+	// Optional. Default: false
+	DisableValueRedaction bool
+
 	// AllowCredentials indicates whether or not the response to the request
 	// can be exposed when the credentials flag is true. When used as part of
 	// a response to a preflight request, this indicates whether or not the
@@ -75,9 +80,10 @@ type Config struct {
 
 // ConfigDefault is the default config
 var ConfigDefault = Config{
-	Next:             nil,
-	AllowOriginsFunc: nil,
-	AllowOrigins:     []string{"*"},
+	Next:                  nil,
+	AllowOriginsFunc:      nil,
+	AllowOrigins:          []string{"*"},
+	DisableValueRedaction: false,
 	AllowMethods: []string{
 		fiber.MethodGet,
 		fiber.MethodPost,

--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -10,6 +10,8 @@ import (
 	utils "github.com/gofiber/utils/v2"
 )
 
+const redactedValue = "[redacted]"
+
 // New creates a new middleware handler
 func New(config ...Config) fiber.Handler {
 	// Set default config
@@ -23,6 +25,15 @@ func New(config ...Config) fiber.Handler {
 		if len(cfg.AllowMethods) == 0 {
 			cfg.AllowMethods = ConfigDefault.AllowMethods
 		}
+	}
+
+	redactValues := !cfg.DisableValueRedaction
+
+	maskValue := func(value string) string {
+		if redactValues {
+			return redactedValue
+		}
+		return value
 	}
 
 	// Warning logs if both AllowOrigins and AllowOriginsFunc are set
@@ -51,7 +62,7 @@ func New(config ...Config) fiber.Handler {
 			withoutWildcard := trimmedOrigin[:i+len("://")] + trimmedOrigin[i+len("://*."):]
 			isValid, normalizedOrigin := normalizeOrigin(withoutWildcard)
 			if !isValid {
-				panic("[CORS] Invalid origin format in configuration: " + trimmedOrigin)
+				panic("[CORS] Invalid origin format in configuration: " + maskValue(trimmedOrigin))
 			}
 			schemeSep := strings.Index(normalizedOrigin, "://") + len("://")
 			sd := subdomain{prefix: normalizedOrigin[:schemeSep], suffix: normalizedOrigin[schemeSep:]}
@@ -59,7 +70,7 @@ func New(config ...Config) fiber.Handler {
 		} else {
 			isValid, normalizedOrigin := normalizeOrigin(trimmedOrigin)
 			if !isValid {
-				panic("[CORS] Invalid origin format in configuration: " + trimmedOrigin)
+				panic("[CORS] Invalid origin format in configuration: " + maskValue(trimmedOrigin))
 			}
 			allowOrigins = append(allowOrigins, normalizedOrigin)
 		}

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -319,6 +319,24 @@ func Test_CORS_Invalid_Origins_Panic(t *testing.T) {
 	}
 }
 
+func Test_CORS_DisableValueRedaction(t *testing.T) {
+	t.Parallel()
+
+	require.PanicsWithValue(t, "[CORS] Invalid origin format in configuration: [redacted]", func() {
+		New(Config{
+			AllowOrigins:          []string{"http://"},
+			DisableValueRedaction: false,
+		})
+	})
+
+	require.PanicsWithValue(t, "[CORS] Invalid origin format in configuration: http://", func() {
+		New(Config{
+			AllowOrigins:          []string{"http://"},
+			DisableValueRedaction: true,
+		})
+	})
+}
+
 // go test -run -v Test_CORS_Subdomain
 func Test_CORS_Subdomain(t *testing.T) {
 	t.Parallel()

--- a/middleware/csrf/config.go
+++ b/middleware/csrf/config.go
@@ -97,6 +97,11 @@ type Config struct {
 	// Optional. Default: 30 * time.Minute
 	IdleTimeout time.Duration
 
+	// DisableValueRedaction turns off masking CSRF tokens and storage keys in logs and errors.
+	//
+	// Optional. Default: false
+	DisableValueRedaction bool
+
 	// CookieSecure indicates if CSRF cookie is secure.
 	//
 	// Optional. Default: false
@@ -125,12 +130,13 @@ const HeaderName = "X-Csrf-Token"
 
 // ConfigDefault is the default config for CSRF middleware.
 var ConfigDefault = Config{
-	CookieName:     "csrf_",
-	CookieSameSite: "Lax",
-	IdleTimeout:    30 * time.Minute,
-	KeyGenerator:   utils.UUIDv4,
-	ErrorHandler:   defaultErrorHandler,
-	Extractor:      extractors.FromHeader(HeaderName),
+	CookieName:            "csrf_",
+	CookieSameSite:        "Lax",
+	IdleTimeout:           30 * time.Minute,
+	KeyGenerator:          utils.UUIDv4,
+	ErrorHandler:          defaultErrorHandler,
+	Extractor:             extractors.FromHeader(HeaderName),
+	DisableValueRedaction: false,
 }
 
 // defaultErrorHandler is the default error handler that processes errors from fiber.Handler.

--- a/middleware/csrf/csrf.go
+++ b/middleware/csrf/csrf.go
@@ -48,13 +48,22 @@ func New(config ...Config) fiber.Handler {
 	// Set default config
 	cfg := configDefault(config...)
 
+	redactKeys := !cfg.DisableValueRedaction
+
+	maskValue := func(value string) string {
+		if redactKeys {
+			return redactedKey
+		}
+		return value
+	}
+
 	// Create manager to simplify storage operations ( see *_manager.go )
 	var sessionManager *sessionManager
 	var storageManager *storageManager
 	if cfg.Session != nil {
 		sessionManager = newSessionManager(cfg.Session)
 	} else {
-		storageManager = newStorageManager(cfg.Storage)
+		storageManager = newStorageManager(cfg.Storage, redactKeys)
 	}
 
 	// Pre-parse trusted origins
@@ -67,7 +76,7 @@ func New(config ...Config) fiber.Handler {
 			withoutWildcard := trimmedOrigin[:i+len("://")] + trimmedOrigin[i+len("://*."):]
 			isValid, normalizedOrigin := normalizeOrigin(withoutWildcard)
 			if !isValid {
-				panic("[CSRF] Invalid origin format in configuration:" + origin)
+				panic("[CSRF] Invalid origin format in configuration:" + maskValue(origin))
 			}
 			schemeSep := strings.Index(normalizedOrigin, "://") + len("://")
 			sd := subdomain{prefix: normalizedOrigin[:schemeSep], suffix: normalizedOrigin[schemeSep:]}
@@ -75,7 +84,7 @@ func New(config ...Config) fiber.Handler {
 		} else {
 			isValid, normalizedOrigin := normalizeOrigin(trimmedOrigin)
 			if !isValid {
-				panic("[CSRF] Invalid origin format in configuration:" + origin)
+				panic("[CSRF] Invalid origin format in configuration:" + maskValue(origin))
 			}
 			trustedOrigins = append(trustedOrigins, normalizedOrigin)
 		}

--- a/middleware/csrf/csrf_test.go
+++ b/middleware/csrf/csrf_test.go
@@ -1732,7 +1732,7 @@ func Test_deleteTokenFromStorage(t *testing.T) {
 
 	store := session.NewStore()
 	sm := newSessionManager(store)
-	stm := newStorageManager(nil)
+	stm := newStorageManager(nil, true)
 
 	sm.setRaw(ctx, token, dummy, time.Minute)
 	require.NoError(t, deleteTokenFromStorage(ctx, token, Config{Session: store}, sm, stm))
@@ -1740,13 +1740,23 @@ func Test_deleteTokenFromStorage(t *testing.T) {
 	require.Nil(t, raw)
 
 	sm2 := newSessionManager(nil)
-	stm2 := newStorageManager(nil)
+	stm2 := newStorageManager(nil, true)
 
 	require.NoError(t, stm2.setRaw(context.Background(), token, dummy, time.Minute))
 	require.NoError(t, deleteTokenFromStorage(ctx, token, Config{}, sm2, stm2))
 	raw, err := stm2.getRaw(context.Background(), token)
 	require.NoError(t, err)
 	require.Nil(t, raw)
+}
+
+func Test_storageManager_logKey(t *testing.T) {
+	t.Parallel()
+
+	redacted := newStorageManager(nil, true)
+	require.Equal(t, redactedKey, redacted.logKey("secret"))
+
+	plain := newStorageManager(nil, false)
+	require.Equal(t, "secret", plain.logKey("secret"))
 }
 
 func Test_CSRF_Chain_Extractor(t *testing.T) {

--- a/middleware/csrf/storage_manager.go
+++ b/middleware/csrf/storage_manager.go
@@ -21,12 +21,13 @@ const redactedKey = "[redacted]"
 //msgp:ignore manager
 //msgp:ignore storageManager
 type storageManager struct {
-	pool    sync.Pool       `msg:"-"` //nolint:revive // Ignore unexported type
-	memory  *memory.Storage `msg:"-"` //nolint:revive // Ignore unexported type
-	storage fiber.Storage   `msg:"-"` //nolint:revive // Ignore unexported type
+	pool       sync.Pool       `msg:"-"` //nolint:revive // Ignore unexported type
+	memory     *memory.Storage `msg:"-"` //nolint:revive // Ignore unexported type
+	storage    fiber.Storage   `msg:"-"` //nolint:revive // Ignore unexported type
+	redactKeys bool
 }
 
-func newStorageManager(storage fiber.Storage) *storageManager {
+func newStorageManager(storage fiber.Storage, redactKeys bool) *storageManager {
 	// Create new storage handler
 	storageManager := &storageManager{
 		pool: sync.Pool{
@@ -34,6 +35,7 @@ func newStorageManager(storage fiber.Storage) *storageManager {
 				return new(item)
 			},
 		},
+		redactKeys: redactKeys,
 	}
 	if storage != nil {
 		// Use provided storage if provided
@@ -70,7 +72,7 @@ func (m *storageManager) getRaw(ctx context.Context, key string) ([]byte, error)
 func (m *storageManager) setRaw(ctx context.Context, key string, raw []byte, exp time.Duration) error {
 	if m.storage != nil {
 		if err := m.storage.SetWithContext(ctx, key, raw, exp); err != nil {
-			return fmt.Errorf("csrf: failed to store key %s: %w", redactedKey, err)
+			return fmt.Errorf("csrf: failed to store key %q: %w", m.logKey(key), err)
 		}
 		return nil
 	}
@@ -84,11 +86,18 @@ func (m *storageManager) setRaw(ctx context.Context, key string, raw []byte, exp
 func (m *storageManager) delRaw(ctx context.Context, key string) error {
 	if m.storage != nil {
 		if err := m.storage.DeleteWithContext(ctx, key); err != nil {
-			return fmt.Errorf("csrf: failed to delete key %s: %w", redactedKey, err)
+			return fmt.Errorf("csrf: failed to delete key %q: %w", m.logKey(key), err)
 		}
 		return nil
 	}
 
 	m.memory.Delete(key)
 	return nil
+}
+
+func (m *storageManager) logKey(key string) string {
+	if m.redactKeys {
+		return redactedKey
+	}
+	return key
 }

--- a/middleware/idempotency/config.go
+++ b/middleware/idempotency/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	//
 	// Optional. Default: an in-memory storage for this process only.
 	Storage fiber.Storage
+
 	// Next defines a function to skip this middleware when returned true.
 	//
 	// Optional. Default: a function which skips the middleware on safe HTTP request method.
@@ -46,6 +47,11 @@ type Config struct {
 	//
 	// Optional. Default: 30 * time.Minute
 	Lifetime time.Duration
+
+	// DisableValueRedaction turns off masking idempotency keys in logs and errors when set to true.
+	//
+	// Optional. Default: false
+	DisableValueRedaction bool
 }
 
 // ConfigDefault is the default config
@@ -70,7 +76,8 @@ var ConfigDefault = Config{
 
 	Lock: nil, // Set in configDefault so we don't allocate data here.
 
-	Storage: nil, // Set in configDefault so we don't allocate data here.
+	Storage:               nil, // Set in configDefault so we don't allocate data here.
+	DisableValueRedaction: false,
 }
 
 // Helper function to set default values

--- a/middleware/limiter/config.go
+++ b/middleware/limiter/config.go
@@ -67,6 +67,11 @@ type Config struct {
 	//
 	// Default: false
 	DisableHeaders bool
+
+	// DisableValueRedaction turns off masking limiter keys in logs and error messages when set to true.
+	//
+	// Default: false
+	DisableValueRedaction bool
 }
 
 // ConfigDefault is the default config
@@ -82,6 +87,7 @@ var ConfigDefault = Config{
 	SkipFailedRequests:     false,
 	SkipSuccessfulRequests: false,
 	DisableHeaders:         false,
+	DisableValueRedaction:  false,
 	LimiterMiddleware:      FixedWindow{},
 }
 

--- a/middleware/limiter/limiter_fixed.go
+++ b/middleware/limiter/limiter_fixed.go
@@ -21,7 +21,7 @@ func (FixedWindow) New(cfg Config) fiber.Handler {
 	)
 
 	// Create manager to simplify storage operations ( see manager.go )
-	manager := newManager(cfg.Storage)
+	manager := newManager(cfg.Storage, !cfg.DisableValueRedaction)
 
 	// Update timestamp every second
 	utils.StartTimeStampUpdater()

--- a/middleware/limiter/limiter_sliding.go
+++ b/middleware/limiter/limiter_sliding.go
@@ -22,7 +22,7 @@ func (SlidingWindow) New(cfg Config) fiber.Handler {
 	)
 
 	// Create manager to simplify storage operations ( see manager.go )
-	manager := newManager(cfg.Storage)
+	manager := newManager(cfg.Storage, !cfg.DisableValueRedaction)
 
 	// Update timestamp every second
 	utils.StartTimeStampUpdater()

--- a/middleware/limiter/manager.go
+++ b/middleware/limiter/manager.go
@@ -21,12 +21,15 @@ type item struct {
 
 //msgp:ignore manager
 type manager struct {
-	pool    sync.Pool
-	memory  *memory.Storage
-	storage fiber.Storage
+	pool       sync.Pool
+	memory     *memory.Storage
+	storage    fiber.Storage
+	redactKeys bool
 }
 
-func newManager(storage fiber.Storage) *manager {
+const redactedKey = "[redacted]"
+
+func newManager(storage fiber.Storage, redactKeys bool) *manager {
 	// Create new storage handler
 	manager := &manager{
 		pool: sync.Pool{
@@ -34,6 +37,7 @@ func newManager(storage fiber.Storage) *manager {
 				return new(item)
 			},
 		},
+		redactKeys: redactKeys,
 	}
 	if storage != nil {
 		// Use provided storage if provided
@@ -63,13 +67,13 @@ func (m *manager) get(ctx context.Context, key string) (*item, error) {
 	if m.storage != nil {
 		raw, err := m.storage.GetWithContext(ctx, key)
 		if err != nil {
-			return nil, fmt.Errorf("limiter: failed to get key %q from storage: %w", key, err)
+			return nil, fmt.Errorf("limiter: failed to get key %q from storage: %w", m.logKey(key), err)
 		}
 		if raw != nil {
 			it := m.acquire()
 			if _, err := it.UnmarshalMsg(raw); err != nil {
 				m.release(it)
-				return nil, fmt.Errorf("limiter: failed to unmarshal key %q: %w", key, err)
+				return nil, fmt.Errorf("limiter: failed to unmarshal key %q: %w", m.logKey(key), err)
 			}
 			return it, nil
 		}
@@ -83,7 +87,7 @@ func (m *manager) get(ctx context.Context, key string) (*item, error) {
 
 	it, ok := value.(*item)
 	if !ok {
-		return nil, fmt.Errorf("limiter: unexpected entry type %T for key %q", value, key)
+		return nil, fmt.Errorf("limiter: unexpected entry type %T for key %q", value, m.logKey(key))
 	}
 
 	return it, nil
@@ -95,11 +99,11 @@ func (m *manager) set(ctx context.Context, key string, it *item, exp time.Durati
 		raw, err := it.MarshalMsg(nil)
 		if err != nil {
 			m.release(it)
-			return fmt.Errorf("limiter: failed to marshal key %q: %w", key, err)
+			return fmt.Errorf("limiter: failed to marshal key %q: %w", m.logKey(key), err)
 		}
 		if err := m.storage.SetWithContext(ctx, key, raw, exp); err != nil {
 			m.release(it)
-			return fmt.Errorf("limiter: failed to store key %q: %w", key, err)
+			return fmt.Errorf("limiter: failed to store key %q: %w", m.logKey(key), err)
 		}
 		m.release(it)
 		return nil
@@ -107,4 +111,11 @@ func (m *manager) set(ctx context.Context, key string, it *item, exp time.Durati
 
 	m.memory.Set(key, it, exp)
 	return nil
+}
+
+func (m *manager) logKey(key string) string {
+	if m.redactKeys {
+		return redactedKey
+	}
+	return key
 }

--- a/router.go
+++ b/router.go
@@ -33,7 +33,8 @@ type Router interface {
 
 	Group(prefix string, handlers ...Handler) Router
 
-	Route(path string) Register
+	RouteChain(path string) Register
+	Route(prefix string, fn func(router Router), name ...string) Router
 
 	Name(name string) Router
 }


### PR DESCRIPTION
# PR Title

🐛 Fix adaptor.FiberApp to handle Unix sockets + ✅ add unit test

# Description

This PR fixes a bug in `adaptor.FiberApp` that caused requests over Unix domain sockets to return a `500 Internal Server Error`.

The issue was due to improper handling of `RemoteAddr` for Unix socket connections. A fallback mechanism has been added to correctly handle requests via Unix sockets.

Additionally, a new unit test has been added to validate Unix socket support.

## Changes introduced

- Fixed `adaptor.FiberApp` to properly handle `RemoteAddr` for Unix socket requests.  
- Added `unixsocket_test.go` to validate Unix domain socket functionality.  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)  
- [x] Enhancement (improvement to existing functionality)  
- [x] Test addition (new unit test for Unix socket support)  

## Checklist

- [x] Self-reviewed the code and added comments where necessary.  
- [x] Added unit test for Unix socket support.  
- [x] Verified all unit tests pass locally.  
- [x] Ensured no unnecessary dependencies were introduced.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DisableValueRedaction (default: false) to Cache, CORS, CSRF, Idempotency and Limiter; introduced RouteChain and new Route(prefix, fn, ...) helper.
* **Bug Fixes**
  * Improved remote-address resolution with safer fallback and added Unix domain socket handling.
* **Documentation**
  * Updated middleware docs and "What's New" to describe redaction behavior and the opt-out flag.
* **Tests**
  * Added/updated tests and a benchmark for redaction toggles, Unix socket adaptor, routing, and multipart file parsing.
* **Chores**
  * Reused file-upload buffers, reduced allocations in request helpers, and avoided unnecessary GC locking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->